### PR TITLE
Add minecraft menu button and download field

### DIFF
--- a/Minecraft.html
+++ b/Minecraft.html
@@ -20,6 +20,7 @@
         <a href="index.html#apps"><span class="material-icons">download</span> <span data-translate="nav_apps">Applications</span></a>
         <a href="index.html#features"><span class="material-icons">star</span> <span data-translate="nav_features">Features</span></a>
         <a href="index.html#contact"><span class="material-icons">contact_support</span> <span data-translate="nav_contact">Contact</span></a>
+        <a href="index.html#whois"><span class="material-icons">person</span> <span data-translate="nav_whois">Who is Zhiwar?</span></a>
         <a href="Minecraft.html"><span class="material-icons">blocks</span> <span data-translate="nav_minecraft">Minecraft</span></a>
       </nav>
       <div class="language-switcher">
@@ -44,6 +45,16 @@
           <span class="material-icons">download</span>
           <span data-translate="minecraft_download_button">Download</span>
         </a>
+      </div>
+    </div>
+  </section>
+
+  <section id="whois" class="login-section">
+    <div class="section-container">
+      <h2 class="section-title" data-translate="whois_title">Who is Zhiwar?</h2>
+      <p class="section-subtitle" data-translate="whois_subtitle">Brief introduction about the developer</p>
+      <div>
+        <p data-translate="whois_body">Zhiwar is a professional Kurdish developer focused on building high-quality mobile apps with a complete Kurdish experience.</p>
       </div>
     </div>
   </section>

--- a/Minecraft.html
+++ b/Minecraft.html
@@ -30,7 +30,7 @@
     </div>
   </header>
 
-  <section class="apps-section">
+  <section id="download" class="apps-section">
     <h2 class="section-title" data-translate="minecraft_section_title">Minecraft download</h2>
     <p class="section-subtitle" data-translate="minecraft_section_subtitle">Latest Minecraft app in Kurdish</p>
 

--- a/Minecraft.html
+++ b/Minecraft.html
@@ -1,1 +1,69 @@
-h
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, minimum-scale=1.0">
+  <title data-translate="minecraft_section_title">Minecraft download</title>
+  <link href="https://fonts.googleapis.com/css2?family=Tajawal:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <script src="translation.js"></script>
+</head>
+<body>
+  <header>
+    <div class="header-container">
+      <a href="index.html" class="logo">
+        <span class="material-icons logo-icon">apps</span>
+        <span data-translate="welcome_title">Welcome to ZHIWAR | Official Website</span>
+      </a>
+      <nav>
+        <a href="index.html#apps"><span class="material-icons">download</span> <span data-translate="nav_apps">Applications</span></a>
+        <a href="index.html#features"><span class="material-icons">star</span> <span data-translate="nav_features">Features</span></a>
+        <a href="index.html#contact"><span class="material-icons">contact_support</span> <span data-translate="nav_contact">Contact</span></a>
+        <a href="Minecraft.html"><span class="material-icons">blocks</span> <span data-translate="nav_minecraft">Minecraft</span></a>
+      </nav>
+      <div class="language-switcher">
+        <button class="lang-btn" data-lang="ku">کوردی</button>
+        <button class="lang-btn" data-lang="ar">العربية</button>
+        <button class="lang-btn active" data-lang="en">English</button>
+      </div>
+    </div>
+  </header>
+
+  <section class="apps-section">
+    <h2 class="section-title" data-translate="minecraft_section_title">Minecraft download</h2>
+    <p class="section-subtitle" data-translate="minecraft_section_subtitle">Latest Minecraft app in Kurdish</p>
+
+    <div class="apps-grid">
+      <div class="app-card">
+        <div class="app-icon"><span class="material-icons">blocks</span></div>
+        <h3 class="app-title" data-translate="app1_title">Minefo Kr</h3>
+        <span class="app-version" data-translate="app1_version">Version 1.0</span>
+        <p class="app-description" data-translate="app1_description">All Minecraft information in Kurdish</p>
+        <a class="btn btn-primary" href="https://github.com/zhiwar404M/Kurdish-Information-MCPE/raw/refs/heads/main/1.0/Kurdish%20Information%20MCPE_1.0%20V.apk" target="_blank" rel="noopener" data-download-with-ads="false">
+          <span class="material-icons">download</span>
+          <span data-translate="minecraft_download_button">Download</span>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <footer id="contact">
+    <div class="footer-content">
+      <div class="footer-column">
+        <h3 data-translate="about_title">About Us</h3>
+        <p data-translate="about_text">My name is Zhiwar, developer of Kurdish apps, and I strive to provide the best for your service 💎❤️.</p>
+      </div>
+      <div class="footer-column">
+        <h3 data-translate="channels_title">Channels</h3>
+        <ul class="footer-links">
+          <li><a href="https://youtube.com/@zhiwarxyt"><span class="material-icons">play_circle</span> <span data-translate="youtube_label">YouTube</span></a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="copyright">
+      <p data-translate="copyright_text">© 2021-2025 All rights reserved. Producer: ZHIWAR</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -112,6 +112,22 @@
     </div>
   </section>
 
+  <!-- Spotlight Section -->
+  <section id="spotlight" class="login-section">
+    <div class="section-container">
+      <h2 class="section-title" data-translate="spotlight_title">Featured apps</h2>
+      <p class="section-subtitle" data-translate="spotlight_subtitle">Hand-picked highlights from our apps</p>
+      <div class="apps-grid">
+        <div class="app-card">
+          <div class="app-icon"><span class="material-icons">workspace_premium</span></div>
+          <h3 class="app-title" data-translate="spotlight_card_title">Premium Experience</h3>
+          <p class="app-description" data-translate="spotlight_card_desc">Carefully crafted apps with quality and performance</p>
+          <a href="#apps" class="btn btn-outline"><span class="material-icons">apps</span> <span data-translate="spotlight_cta">Explore Apps</span></a>
+        </div>
+      </div>
+    </div>
+  </section>
+
 <!-- Login Section -->
 <section id="login" class="login-section">
   <!-- ... login form ... -->
@@ -143,26 +159,6 @@
       </div>
     </div>
   </section>
-
-  <!-- Minecraft Download Section -->
-  <section id="minecraft" class="apps-section">
-    <h2 class="section-title" data-translate="minecraft_section_title">Minecraft download</h2>
-    <p class="section-subtitle" data-translate="minecraft_section_subtitle">Latest Minecraft app in Kurdish</p>
-
-    <div class="apps-grid">
-      <div class="app-card">
-        <div class="app-icon"><span class="material-icons">blocks</span></div>
-        <h3 class="app-title" data-translate="app1_title">Minefo Kr</h3>
-        <span class="app-version" data-translate="app1_version">Version 1.0</span>
-        <p class="app-description" data-translate="app1_description">All Minecraft information in Kurdish</p>
-        <button class="btn btn-primary" onclick="startDownloadWithAds('https://github.com/zhiwar404M/Kurdish-Information-MCPE/raw/refs/heads/main/1.0/Kurdish%20Information%20MCPE_1.0%20V.apk')">
-          <span class="material-icons">download</span>
-          <span data-translate="minecraft_download_button">Download</span>
-        </button>
-      </div>
-    </div>
-    
-
 
   <!-- Privacy Policy Section -->
   <section class="privacy-section">
@@ -504,6 +500,31 @@
         "ku": "داگرتن",
         "ar": "تحميل",
         "en": "Download"
+      },
+      "spotlight_title": {
+        "ku": "بەرنامە هێڵکراوەکان",
+        "ar": "تطبيقات مميزة",
+        "en": "Featured apps"
+      },
+      "spotlight_subtitle": {
+        "ku": "هەڵبژاردەیەکی تایبەتی لە کارەکانمان",
+        "ar": "مختارات مميزة من تطبيقاتنا",
+        "en": "Hand-picked highlights from our apps"
+      },
+      "spotlight_card_title": {
+        "ku": "تجارەتی پەروەردە",
+        "ar": "تجربة مميزة",
+        "en": "Premium Experience"
+      },
+      "spotlight_card_desc": {
+        "ku": "بەرنامەکان بە وردەکاری و کارایی دروستکراون",
+        "ar": "تطبيقات مصممة بعناية للجودة والأداء",
+        "en": "Carefully crafted apps with quality and performance"
+      },
+      "spotlight_cta": {
+        "ku": "سەیرکردنی بەرنامەکان",
+        "ar": "استكشاف التطبيقات",
+        "en": "Explore Apps"
       },
       "privacy_title": {
         "ku": "سیاسەتی پاراستنی زانیاری",

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
         <a href="#features"><span class="material-icons">star</span> <span data-translate="nav_features">Features</span></a>
         <a href="#contact"><span class="material-icons">contact_support</span> <span data-translate="nav_contact">Contact</span></a>
 
-        <a href="#Minecraft.html"><span class="material-icons">blocks</span> <span data-translate="nav_apps">Minecraft download</span></a>
+        <a href="#minecraft"><span class="material-icons">blocks</span> <span data-translate="nav_minecraft">Minecraft</span></a>
 
                   <a href="#login" id="loginNavLink" onclick="var o=document.getElementById('loginModalOverlay'); if(o){o.style.display='flex'; document.body.style.overflow='hidden';} return false;"><span class="material-icons">login</span> <span data-translate="nav_login">Login</span></a>
         <div id="userChip" class="user-chip" style="display:none;">
@@ -132,6 +132,25 @@
         <p class="app-description" data-translate="app1_description">تەواوی زانیاریەکانی مایکرافت بە زمانی کوردی</p>
         <button class="btn btn-primary" onclick="startDownloadWithAds('https://github.com/zhiwar404M/Kurdish-Information-MCPE/raw/refs/heads/main/1.0/Kurdish%20Information%20MCPE_1.0%20V.apk')">
           <span class="material-icons">download</span> <span data-translate="app1_button">داگرتن بۆ ئەندرۆید</span>
+        </button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Minecraft Download Section -->
+  <section id="minecraft" class="apps-section">
+    <h2 class="section-title" data-translate="minecraft_section_title">Minecraft download</h2>
+    <p class="section-subtitle" data-translate="minecraft_section_subtitle">Latest Minecraft app in Kurdish</p>
+
+    <div class="apps-grid">
+      <div class="app-card">
+        <div class="app-icon"><span class="material-icons">blocks</span></div>
+        <h3 class="app-title" data-translate="app1_title">Minefo Kr</h3>
+        <span class="app-version" data-translate="app1_version">Version 1.0</span>
+        <p class="app-description" data-translate="app1_description">All Minecraft information in Kurdish</p>
+        <button class="btn btn-primary" onclick="startDownloadWithAds('https://github.com/zhiwar404M/Kurdish-Information-MCPE/raw/refs/heads/main/1.0/Kurdish%20Information%20MCPE_1.0%20V.apk')">
+          <span class="material-icons">download</span>
+          <span data-translate="minecraft_download_button">Download</span>
         </button>
       </div>
     </div>
@@ -404,6 +423,11 @@
         "ar": "اتصل بنا",
         "en": "Contact"
       },
+      "nav_minecraft": {
+        "ku": "ماینکرافت",
+        "ar": "ماين كرافت",
+        "en": "Minecraft"
+      },
       "hero_title": {
         "ku": "بەرنامەکانی ZHIWAR",
         "ar": "تطبيقات ZHIWAR",
@@ -453,6 +477,21 @@
         "ku": "داگرتن بۆ ئەندرۆید",
         "ar": "تحميل للأندرويد",
         "en": "Download for Android"
+      },
+      "minecraft_section_title": {
+        "ku": "داگرتنی ماینکرافت",
+        "ar": "تحميل ماين كرافت",
+        "en": "Minecraft download"
+      },
+      "minecraft_section_subtitle": {
+        "ku": "دواوەشانی بەرنامەی ماینکرافت بە کوردی",
+        "ar": "أحدث إصدار لتطبيق ماين كرافت بالكردية",
+        "en": "Latest Minecraft app in Kurdish"
+      },
+      "minecraft_download_button": {
+        "ku": "داگرتن",
+        "ar": "تحميل",
+        "en": "Download"
       },
       "privacy_title": {
         "ku": "سیاسەتی پاراستنی زانیاری",

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
         <a href="#features"><span class="material-icons">star</span> <span data-translate="nav_features">Features</span></a>
         <a href="#contact"><span class="material-icons">contact_support</span> <span data-translate="nav_contact">Contact</span></a>
 
-        <a href="#minecraft"><span class="material-icons">blocks</span> <span data-translate="nav_minecraft">Minecraft</span></a>
+        <a href="Minecraft.html"><span class="material-icons">blocks</span> <span data-translate="nav_minecraft">Minecraft</span></a>
 
                   <a href="#login" id="loginNavLink" onclick="var o=document.getElementById('loginModalOverlay'); if(o){o.style.display='flex'; document.body.style.overflow='hidden';} return false;"><span class="material-icons">login</span> <span data-translate="nav_login">Login</span></a>
         <div id="userChip" class="user-chip" style="display:none;">
@@ -130,9 +130,9 @@
         <h3 class="app-title" data-translate="app1_title">Minefo Kr</h3>
         <span class="app-version" data-translate="app1_version">وەشانی 1.0</span>
         <p class="app-description" data-translate="app1_description">تەواوی زانیاریەکانی مایکرافت بە زمانی کوردی</p>
-        <button class="btn btn-primary" onclick="startDownloadWithAds('https://github.com/zhiwar404M/Kurdish-Information-MCPE/raw/refs/heads/main/1.0/Kurdish%20Information%20MCPE_1.0%20V.apk')">
+        <a href="Minecraft.html" class="btn btn-primary">
           <span class="material-icons">download</span> <span data-translate="app1_button">داگرتن بۆ ئەندرۆید</span>
-        </button>
+        </a>
       </div>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
         <a href="#apps"><span class="material-icons">download</span> <span data-translate="nav_apps">Apps Section</span></a>
         <a href="#features"><span class="material-icons">star</span> <span data-translate="nav_features">Features</span></a>
         <a href="#contact"><span class="material-icons">contact_support</span> <span data-translate="nav_contact">Contact</span></a>
+        <a href="#whois"><span class="material-icons">person</span> <span data-translate="nav_whois">Who is Zhiwar?</span></a>
 
         <a href="Minecraft.html#download"><span class="material-icons">blocks</span> <span data-translate="nav_minecraft">Minecraft</span></a>
 
@@ -100,10 +101,16 @@
   
   
   
-  <!-- Features Section -->
-<section id="features" class="features">
-  <!-- ... existing features content ... -->
-</section>
+  <!-- Who is Zhiwar Section -->
+  <section id="whois" class="login-section">
+    <div class="section-container">
+      <h2 class="section-title" data-translate="whois_title">Who is Zhiwar?</h2>
+      <p class="section-subtitle" data-translate="whois_subtitle">Brief introduction about the developer</p>
+      <div>
+        <p data-translate="whois_body">Zhiwar is a professional Kurdish developer focused on building high-quality mobile apps with a complete Kurdish experience.</p>
+      </div>
+    </div>
+  </section>
 
 <!-- Login Section -->
 <section id="login" class="login-section">
@@ -423,6 +430,11 @@
         "ar": "اتصل بنا",
         "en": "Contact"
       },
+      "nav_whois": {
+        "ku": "ژیوار کێیە؟",
+        "ar": "من هو ژيوار؟",
+        "en": "Who is Zhiwar?"
+      },
       "nav_minecraft": {
         "ku": "ماینکرافت",
         "ar": "ماين كرافت",
@@ -497,6 +509,21 @@
         "ku": "سیاسەتی پاراستنی زانیاری",
         "ar": "سياسة الخصوصية",
         "en": "Privacy Policy"
+      },
+      "whois_title": {
+        "ku": "ژیوار کێیە؟",
+        "ar": "من هو ژيوار؟",
+        "en": "Who is Zhiwar?"
+      },
+      "whois_subtitle": {
+        "ku": "ناسینەوەیەکی کورت لەسەر پەرەپێدەری وێبسایت",
+        "ar": "نبذة قصيرة عن المطور",
+        "en": "Brief introduction about the developer"
+      },
+      "whois_body": {
+        "ku": "ژیوار پەرەپێدەری کوردییەکی پیشەگەرە کە سەرنجی دەدات بە دروستکردنی بەرنامەکانی مۆبایل بە تەجڕەیەکی تەواو بە زمانی کوردی.",
+        "ar": "ژيوار مطور كردي محترف يركز على بناء تطبيقات جوال عالية الجودة بتجربة كردية كاملة.",
+        "en": "Zhiwar is a professional Kurdish developer focused on building high-quality mobile apps with a complete Kurdish experience."
       },
       "privacy_date": {
         "ku": "دوایین نوێکردنەوە: ٢٥ی تشرینی یەکەمی ٢٠٢٥",

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
         <a href="#features"><span class="material-icons">star</span> <span data-translate="nav_features">Features</span></a>
         <a href="#contact"><span class="material-icons">contact_support</span> <span data-translate="nav_contact">Contact</span></a>
 
-        <a href="Minecraft.html"><span class="material-icons">blocks</span> <span data-translate="nav_minecraft">Minecraft</span></a>
+        <a href="Minecraft.html#download"><span class="material-icons">blocks</span> <span data-translate="nav_minecraft">Minecraft</span></a>
 
                   <a href="#login" id="loginNavLink" onclick="var o=document.getElementById('loginModalOverlay'); if(o){o.style.display='flex'; document.body.style.overflow='hidden';} return false;"><span class="material-icons">login</span> <span data-translate="nav_login">Login</span></a>
         <div id="userChip" class="user-chip" style="display:none;">
@@ -130,7 +130,7 @@
         <h3 class="app-title" data-translate="app1_title">Minefo Kr</h3>
         <span class="app-version" data-translate="app1_version">وەشانی 1.0</span>
         <p class="app-description" data-translate="app1_description">تەواوی زانیاریەکانی مایکرافت بە زمانی کوردی</p>
-        <a href="Minecraft.html" class="btn btn-primary">
+        <a href="Minecraft.html#download" class="btn btn-primary">
           <span class="material-icons">download</span> <span data-translate="app1_button">داگرتن بۆ ئەندرۆید</span>
         </a>
       </div>

--- a/translation.js
+++ b/translation.js
@@ -249,6 +249,26 @@ const translations = {
         "ku": "چوونەژوورەوە",
         "ar": "سجل الدخول",
         "en": "Sign in"
+    },
+    "nav_minecraft": {
+        "ku": "ماینکرافت",
+        "ar": "ماين كرافت",
+        "en": "Minecraft"
+    },
+    "minecraft_section_title": {
+        "ku": "داگرتنی ماینکرافت",
+        "ar": "تحميل ماين كرافت",
+        "en": "Minecraft download"
+    },
+    "minecraft_section_subtitle": {
+        "ku": "دواوەشانی بەرنامەی ماینکرافت بە کوردی",
+        "ar": "أحدث إصدار لتطبيق ماين كرافت بالكردية",
+        "en": "Latest Minecraft app in Kurdish"
+    },
+    "minecraft_download_button": {
+        "ku": "داگرتن",
+        "ar": "تحميل",
+        "en": "Download"
     }
 };
 

--- a/translation.js
+++ b/translation.js
@@ -250,6 +250,26 @@ const translations = {
         "ar": "سجل الدخول",
         "en": "Sign in"
     },
+    "nav_whois": {
+        "ku": "ژیوار کێیە؟",
+        "ar": "من هو ژيوار؟",
+        "en": "Who is Zhiwar?"
+    },
+    "whois_title": {
+        "ku": "ژیوار کێیە؟",
+        "ar": "من هو ژيوار؟",
+        "en": "Who is Zhiwar?"
+    },
+    "whois_subtitle": {
+        "ku": "ناسینەوەیەکی کورت لەسەر پەرەپێدەری وێبسایت",
+        "ar": "نبذة قصيرة عن المطور",
+        "en": "Brief introduction about the developer"
+    },
+    "whois_body": {
+        "ku": "ژیوار پەرەپێدەری کوردییەکی پیشەگەرە کە سەرنجی دەدات بە دروستکردنی بەرنامەکانی مۆبایل بە تەجڕەیەکی تەواو بە زمانی کوردی.",
+        "ar": "ژيوار مطور كردي محترف يركز على بناء تطبيقات جوال عالية الجودة بتجربة كردية كاملة.",
+        "en": "Zhiwar is a professional Kurdish developer focused on building high-quality mobile apps with a complete Kurdish experience."
+    },
     "nav_minecraft": {
         "ku": "ماینکرافت",
         "ar": "ماين كرافت",

--- a/translation.js
+++ b/translation.js
@@ -289,6 +289,31 @@ const translations = {
         "ku": "داگرتن",
         "ar": "تحميل",
         "en": "Download"
+    },
+    "spotlight_title": {
+        "ku": "بەرنامە هێڵکراوەکان",
+        "ar": "تطبيقات مميزة",
+        "en": "Featured apps"
+    },
+    "spotlight_subtitle": {
+        "ku": "هەڵبژاردەیەکی تایبەتی لە کارەکانمان",
+        "ar": "مختارات مميزة من تطبيقاتنا",
+        "en": "Hand-picked highlights from our apps"
+    },
+    "spotlight_card_title": {
+        "ku": "تجارەتی پەروەردە",
+        "ar": "تجربة مميزة",
+        "en": "Premium Experience"
+    },
+    "spotlight_card_desc": {
+        "ku": "بەرنامەکان بە وردەکاری و کارایی دروستکراون",
+        "ar": "تطبيقات مصممة بعناية للجودة والأداء",
+        "en": "Carefully crafted apps with quality and performance"
+    },
+    "spotlight_cta": {
+        "ku": "سەیرکردنی بەرنامەکان",
+        "ar": "استكشاف التطبيقات",
+        "en": "Explore Apps"
     }
 };
 


### PR DESCRIPTION
Add a 'Minecraft' menu item and a dedicated 'Minecraft download' section to the homepage as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-48075848-9588-40d8-8a3b-c12212219a21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-48075848-9588-40d8-8a3b-c12212219a21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

